### PR TITLE
Removed Deprecated Selectors (for Atom v1.13.0)

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,13 +1,13 @@
 @import "colors.less";
 
 // EDITOR BACKGROUND & FONT COLORS
-.atom-text-editor, :host {
+.atom-text-editor,atom-text-editor {
   background-color: @code-background;
   color: @code-font-color;
 }
 
 // MAIN CODE EDITOR STYLES
-.atom-text-editor, :host {
+.atom-text-editor,atom-text-editor {
 
   background-color: @code-background;
   color: @code-font-color;

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,34 +1,34 @@
 @import "colors";
 
-.html {
+.syntax--html {
 
-  .meta.tag.any {
+  .syntax--meta.syntax--tag.syntax--any {
     color: @green;
   }
 
-  .entity.name.tag {
-    &.block, &.inline, &.name {
+  .syntax--entity.syntax--name.syntax--tag {
+    &.syntax--block, &.syntax--inline, &.syntax--name {
       color: @tag;
     }
   }
 
-  .entity.other.attribute-name.id.html {
+  .syntax--entity.syntax--other.syntax--attribute-name.syntax--id.syntax--html {
     color: @id;
   }
 
-  .punctuation.separator.key-value {
+  .syntax--punctuation.syntax--separator.syntax--key-value {
     color: @green;
   }
 
-  .string.quoted.double {
+  .syntax--string.syntax--quoted.syntax--double {
     color: lighten(@green, 20%);
 
-    .punctuation.definition.string {
-      &.begin, &.end {
+    .syntax--punctuation.syntax--definition.syntax--string {
+      &.syntax--begin, &.syntax--end {
         color: @green;
       }
 
-      .separator.key-value.html {
+      .syntax--separator.syntax--key-value.syntax--html {
         color: @green;
       }
 

--- a/styles/languages/jade.less
+++ b/styles/languages/jade.less
@@ -1,65 +1,66 @@
 @import "colors";
 
 
-.jade {
+.syntax--jade {
 
   color: @code-font-color;
 
-  .comment.jade {
+  .syntax--comment.syntax--jade {
     color: @comment;
   }
 
-  .storage.type.function.jade {
+  .syntax--storage.syntax--type.syntax--function.syntax--jade {
     color: @keyword;
   }
 
-  .meta.control.flow.jade {
+  .syntax--meta.syntax--control.syntax--flow.syntax--jade {
     color: @red;
   }
 
-  .source.script {
-    .meta.brace.round.js, .meta.brace.curly.js {
+  .syntax--source.syntax--script {
+    .syntax--meta.syntax--brace.syntax--round.syntax--js,
+    .syntax--meta.syntax--brace.syntax--curly.syntax--js {
       color: @brackets;
     }
   }
 
-  .entity {
+  .syntax--entity {
 
-    &.name.tag.jade {
+    &.syntax--name.syntax--tag.syntax--jade {
       color: @tag;
     }
 
   }
 
-  .storage.type.import.include.jade {
+  .syntax--storage.syntax--type.syntax--import.syntax--include.syntax--jade {
     color: lighten(@green, 20%);
   }
 
-  .variable.control.import.include.jade {
+  .syntax--variable.syntax--control.syntax--import.syntax--include.syntax--jade {
     color: @green;
   }
 
-  .constant {
+  .syntax--constant {
 
-    &.id {
+    &.syntax--id {
       color: @yellow;
     }
 
-    &.language.js {
+    &.syntax--language.syntax--js {
       color: @purple;
     }
 
   }
 
-  .text.jade {
+  .syntax--text.syntax--jade {
     color: @code-font-color;
   }
 
-  .punctuation.separator.key-value.jade {
+  .syntax--punctuation.syntax--separator.syntax--key-value.syntax--jade {
     color: @tag;
   }
 
-  .string.quoted.jade {
+  .syntax--string.syntax--quoted.syntax--jade {
     color: @code-font-color;
   }
 

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,46 +1,46 @@
 @import "colors";
 
 
-.source.json {
+.syntax--source.syntax--json {
 
-  .constant.language {
+  .syntax--constant.syntax--language {
     color: @constant;
   }
 
-  .meta.structure.dictionary.json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
 
-    .string.quoted.json {
+    .syntax--string.syntax--quoted.syntax--json {
       color: @tag;
     }
 
-    .meta.structure.dictionary.value.json {
+    .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json {
       // background-color: pink;
-      .string.quoted.json {
+      .syntax--string.syntax--quoted.syntax--json {
         color: @code-font-color;
 
-        .punctuation.definition.string {
+        .syntax--punctuation.syntax--definition.syntax--string {
           color: @code-font-color;
         }
       }
 
-      .meta.structure.dictionary.json {
+      .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
         // background-color: yellow;
 
-        .string.quoted.json {
+        .syntax--string.syntax--quoted.syntax--json {
           color: @tag;
 
-          .punctuation.definition.string {
+          .syntax--punctuation.syntax--definition.syntax--string {
             color: @tag;
           }
         }
 
-        .meta.structure.dictionary.value.json {
+        .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json {
             // background-color: orange;
 
-            .string.quoted.json {
+            .syntax--string.syntax--quoted.syntax--json {
               color: @code-font-color;
 
-              .punctuation.definition.string {
+              .syntax--punctuation.syntax--definition.syntax--string {
                 color: @code-font-color;
               }
             }

--- a/styles/languages/mustache.less
+++ b/styles/languages/mustache.less
@@ -1,11 +1,11 @@
 @import "colors";
 
-.mustache {
+.syntax--mustache {
 
-  .meta.tag.template {
+  .syntax--meta.syntax--tag.syntax--template {
     color: @green;
 
-    .entity.name.tag {
+    .syntax--entity.syntax--name.syntax--tag {
       color: lighten(@green, 20%);
     }
   }

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -1,100 +1,100 @@
 @import "colors.less";
 
-.comment {
+.syntax--comment {
   color: @comment;
   background: @comment-bg;
 }
 
-.keyword {
+.syntax--keyword {
   // @ of @font-face & @media
   color: @keyword;
 
   // try, catch, if, else, return (js)
-  &.control {
+  &.syntax--control {
     color: @keyword;
   }
 
   // =, +, -, ?, :, !=. &&, in (js)
-  &.operator {
+  &.syntax--operator {
     color: @keyword;
   }
 
   // can't tell what this does :/
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @keyword;
   }
 
   // can't tell what this does :/
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @keyword;
   }
 }
 
 
 // STORAGE |
-.storage {
+.syntax--storage {
   color: @storage;
 
   // var of var a = b;
-  &.modifier {
+  &.syntax--modifier {
     color: @storage;
   }
 
 }
 
 
-.constant {
+.syntax--constant {
 
   // true, false, null, undefined
   color: @constant;
 
   // \ of ("what\'s")
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @constant;
   }
 
   // all the numbers!
-  &.numeric {
+  &.syntax--numeric {
     color: @numeric;
   }
 
   // can't tell what this does :/
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @constant;
   }
 
   // can't tell what this does :/
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @constant;
   }
 }
 
-.variable {
+.syntax--variable {
 
   // this (js), @varable_name (sass), http://web.com of url(http://web.com), variable of {{variable}} (handlebars)
   color: @variable;
 
   // can't tell what this does
-  &.interpolation {
+  &.syntax--interpolation {
     color: @variable;
   }
 
   // foo & bar of function name(foo, bar)
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @function-param;
   }
 }
 
 
 // INVALID TEXT
-.invalid.illegal, .invalid.deprecated {
+.syntax--invalid.syntax--illegal, .syntax--invalid.syntax--deprecated {
   background: none;
   color: @error;
 }
 
-.string {
+.syntax--string {
 
-  .json {
+  .syntax--json {
 
   }
 
@@ -102,109 +102,109 @@
   color: @string;
 
   // REGEX - [\da-z] of /-([\da-z])/gi (js)
-  .constant {
+  .syntax--constant {
     color: @regex;
   }
 
-  &.regexp {
+  &.syntax--regexp {
 
     // ?:input, select, textarea, button of  /^(?:input|select|textarea|button)$/i,
     color: @regex;
 
-    .constant.character.escape,
-    .source.ruby.embedded,
-    .string.regexp.arbitrary-repitition {
+    .syntax--constant.syntax--character.syntax--escape,
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
       color: @regex;
     }
 
-    &.group {
+    &.syntax--group {
       color: @regex;
     }
 
-    &.character-class {
+    &.syntax--character-class {
       color: @regex;
     }
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @regex;
     }
 
   }
 
   // site.dir in {{site.dir}}
-  .variable {
+  .syntax--variable {
     color: @variable;
   }
 
   // can't tell what this does :/
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @string;
   }
 }
 
 // String interpolation in Ruby, CoffeeScript, and others
-.source .string {
-  .source,
-  .meta.embedded.line {
+.syntax--source .syntax--string {
+  .syntax--source,
+  .syntax--meta.syntax--embedded.line {
     color: @string;
   }
 
-  .punctuation.section.embedded {
+  .syntax--punctuation.syntax--section.syntax--embedded {
     color: @string;
 
-    .source {
+    .syntax--source {
       color: @string;  // Required for the end of embedded strings in Ruby # 716
     }
   }
 }
 
 // MISC PUNCTUATION
-.punctuation {
+.syntax--punctuation {
 
-  &.terminator {
+  &.syntax--terminator {
     color: @punctuation;
   }
 
-  &.separator {
+  &.syntax--separator {
     color: @punctuation;
   }
 
-  &.definition {
+  &.syntax--definition {
 
     color: @punctuation;
 
-    &.comment {
+    &.syntax--comment {
       color: @comment-punc;
     }
 
     // QUOTES
-    &.string,
-    &.variable,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--array {
       color: @string;
     }
 
-    &.parameters {
+    &.syntax--parameters {
       color: @code-font-color;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @code-font-color;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @code-font-color;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @code-font-color;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: @code-font-color;
   }
 
@@ -212,87 +212,87 @@
 
 
 
-.support {
+.syntax--support {
 
   // background of background: none,
   color: @support;
 
   // SUPPORT | module of module.exports
-  &.class {
+  &.syntax--class {
     color: @support;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @support; // .log of console.log, url of url(http://web.com)
 
     // can't tell what this does :/
-    &.any-method {
+    &.syntax--any-method {
       color: @support;
     }
   }
 
   // {{}} of {{ variable }}
-  &.constant {
+  &.syntax--constant {
     color: @constant;  // none of text-decoration: none;
   }
 
-  &.type.property-name.css {
+  &.syntax--type.syntax--property-name.syntax--css {
     color:  @css-code-font-color;
   }
 }
 
-// .class names in css & scss
-.source .entity.name.tag, .source .entity.other.attribute-name, .meta.tag.inline, .meta.tag.inline .entity {
+// .syntax--class names in css & scss
+.syntax--source .syntax--entity.syntax--name.syntax--tag, .syntax--source .syntax--entity.syntax--other.syntax--attribute-name, .syntax--meta.syntax--tag.syntax--inline, .syntax--meta.syntax--tag.syntax--inline .syntax--entity {
   color: @class;
 }
 
-  &.tag,
-  &.tag .entity {
+  &.syntax--tag,
+  &.syntax--tag .syntax--entity {
     color: @tag-entity;
   }
 
 
-.html {
+.syntax--html {
 
-  .string {
+  .syntax--string {
     color: @code-font-color;
   }
 
 
   // inline elements - <span>
-  .meta {
+  .syntax--meta {
 
 
   }
 
-  .punctuation.definition.tag {
+  .syntax--punctuation.syntax--definition.syntax--tag {
     color: @tag;
   }
 
-  .entity {
+  .syntax--entity {
 
-    &.name.tag {
+    &.syntax--name.syntax--tag {
       text-decoration: done;
 
       // structural elements - <html>
-      &.structure {
+      &.syntax--structure {
         color: @tag;
       }
 
       // block level elements - <div>, <h1>
-      &.block {
+      &.syntax--block {
         color: @tag;
       }
 
       // inline elements - <span>
-      &.script {
+      &.syntax--script {
         // color: @tag;
       }
 
     }
 
-    &.other {
-      &.attribute-name {
+    &.syntax--other {
+      &.syntax--attribute-name {
         color: @element-attr;
       }
     }
@@ -301,144 +301,144 @@
 
 }
 
-// ENTITY | exports of module.exports, <div id= of <div id="#id">, . of .className
-.entity {
+// ENTITY | exports of module.exports, <div id= of <div id="#id">, . of .syntax--className
+.syntax--entity {
 
   color: @entity;
 
   // console of console.log (js)
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @entity;
     text-decoration: none;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @entity;
   }
 
   // init in init: function(){} (js)
-  &.name.function {
+  &.syntax--name.syntax--function {
     color: @entity;
   }
 
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @entity;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @entity;
   }
 
   // div of <div> (html), body of body{} (css)
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @tag;
     text-decoration: done;
   }
 
 
   // CSS CLASSES
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @element-attr;
 
     // CSS ID's
-    &.id {
+    &.syntax--id {
       color: @id;
     }
   }
 }
 
-.meta {
+.syntax--meta {
 
-  &.link {
+  &.syntax--link {
     color: @meta;
   }
 
-  &.require {
+  &.syntax--require {
     color: @meta;
   }
 
 
-  &.brace {
+  &.syntax--brace {
 
     // curly braces - {}
-    &.curly {
+    &.syntax--curly {
       color: @brackets;
     }
 
     // parenthesis - ()
-    &.round {
+    &.syntax--round {
       color: @code-font-color;
     }
   }
 
-  &.comma {
+  &.syntax--comma {
     color: @punctuation;
   }
 
-  // .css files | commas, ([controls]) of audio:not([controls])
-  &.selector {
+  // .syntax--css files | commas, ([controls]) of audio:not([controls])
+  &.syntax--selector {
     color: @punctuation;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @punctuation;
     color: @punctuation;
   }
 }
 
-.none {
+.syntax--none {
   color: @code-font-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @markup;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @markup;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @markup;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @markup;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @markup;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @markup;
   }
 
-  &.list {
+  &.syntax--list {
     color: @markup;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @markup;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @markup;
   }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
   -webkit-font-smoothing: auto;
-  &.heading {
+  &.syntax--heading {
     color: @code-font-color;
   }
 }
 
 
-atom-text-editor[mini], :host(.mini) {
+atom-text-editor[mini],atom-text-editor(.mini) {
  .scroll-view {
     padding-left: 1px;
   }


### PR DESCRIPTION
Hi there,

I noticed a lot of deprecation warnings for this theme when running under recent Atom versions. This PR will update them to the new selectors. I have verified that this removes all of the deprecation warnings, but I haven't done a side-by-side to verify that everything looks the same. At first glance, the highlighting seems unchanged, but I haven't tested all supported languages.

The following is the original deprecation message I received while starting with the theme in __Atom v1.23.3__.

<details><summary>Deprecation Message</summary>
    <p>

**Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:**

- `.atom-text-editor, :host => .atom-text-editor,atom-text-editor`
- `.atom-text-editor, :host => .atom-text-editor,atom-text-editor`
- `.atom-text-editor .wrap-guide, :host .wrap-guide => .atom-text-editor .wrap-guide,atom-text-editor .wrap-guide`
- `.atom-text-editor .indent-guide, :host .indent-guide => .atom-text-editor .indent-guide,atom-text-editor .indent-guide`
- `.atom-text-editor .invisible-character, :host .invisible-character => .atom-text-editor .invisible-character,atom-text-editor .invisible-character`
- `.atom-text-editor .gutter, :host .gutter => .atom-text-editor .gutter,atom-text-editor .gutter`
- `.atom-text-editor .gutter .line-number, :host .gutter .line-number => .atom-text-editor .gutter .line-number,atom-text-editor .gutter .line-number`
- `.atom-text-editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line => .atom-text-editor .gutter .line-number.cursor-line,atom-text-editor .gutter .line-number.cursor-line`
- `.atom-text-editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection => .atom-text-editor .gutter .line-number.cursor-line-no-selection,atom-text-editor .gutter .line-number.cursor-line-no-selection`
- `.atom-text-editor .gutter .line-number:hover, :host .gutter .line-number:hover => .atom-text-editor .gutter .line-number:hover,atom-text-editor .gutter .line-number:hover`
- `.atom-text-editor .gutter .line-number.folded, :host .gutter .line-number.folded, .atom-text-editor .gutter .line-number:after, :host .gutter .line-number:after, .atom-text-editor .fold-marker:after, :host .fold-marker:after => .atom-text-editor .gutter .line-number.folded,atom-text-editor .gutter .line-number.folded, .atom-text-editor .gutter .line-number:after,atom-text-editor .gutter .line-number:after, .atom-text-editor .fold-marker:after,atom-text-editor .fold-marker:after`
- `.atom-text-editor .invisible, :host .invisible => .atom-text-editor .invisible,atom-text-editor .invisible`
- `.atom-text-editor .cursor, :host .cursor => .atom-text-editor .cursor,atom-text-editor .cursor`
- `.atom-text-editor .selection .region, :host .selection .region => .atom-text-editor .selection .region,atom-text-editor .selection .region`
- `.atom-text-editor .scroll-view, :host .scroll-view => .atom-text-editor .scroll-view,atom-text-editor .scroll-view`
- `.atom-text-editor .line.cursor-line, :host .line.cursor-line => .atom-text-editor .line.cursor-line,atom-text-editor .line.cursor-line`
- `.comment => .syntax--comment`
- `.keyword => .syntax--keyword`
- `.keyword.control => .syntax--keyword.syntax--control`
- `.keyword.operator => .syntax--keyword.syntax--operator`
- `.keyword.other.special-method => .syntax--keyword.syntax--other.syntax--special-method`
- `.keyword.other.unit => .syntax--keyword.syntax--other.syntax--unit`
- `.storage => .syntax--storage`
- `.storage.modifier => .syntax--storage.syntax--modifier`
- `.constant => .syntax--constant`
- `.constant.character.escape => .syntax--constant.syntax--character.syntax--escape`
- `.constant.numeric => .syntax--constant.syntax--numeric`
- `.constant.other.color => .syntax--constant.syntax--other.syntax--color`
- `.constant.other.symbol => .syntax--constant.syntax--other.syntax--symbol`
- `.variable => .syntax--variable`
- `.variable.interpolation => .syntax--variable.syntax--interpolation`
- `.variable.parameter.function => .syntax--variable.syntax--parameter.syntax--function`
- `.invalid.illegal, .invalid.deprecated => .syntax--invalid.syntax--illegal, .syntax--invalid.syntax--deprecated`
- `.string => .syntax--string`
- `.string .constant => .syntax--string .syntax--constant`
- `.string.regexp => .syntax--string.syntax--regexp`
- `.string.regexp .constant.character.escape, .string.regexp .source.ruby.embedded, .string.regexp .string.regexp.arbitrary-repitition => .syntax--string.syntax--regexp .syntax--constant.syntax--character.syntax--escape, .syntax--string.syntax--regexp .syntax--source.syntax--ruby.syntax--embedded, .syntax--string.syntax--regexp .syntax--string.syntax--regexp.syntax--arbitrary-repitition`
- `.string.regexp.group => .syntax--string.syntax--regexp.syntax--group`
- `.string.regexp.character-class => .syntax--string.syntax--regexp.syntax--character-class`
- `.string.regexp .source.ruby.embedded => .syntax--string.syntax--regexp .syntax--source.syntax--ruby.syntax--embedded`
- `.string .variable => .syntax--string .syntax--variable`
- `.string.other.link => .syntax--string.syntax--other.syntax--link`
- `.source .string .source, .source .string .meta.embedded.line => .syntax--source .syntax--string .syntax--source, .syntax--source .syntax--string .syntax--meta.syntax--embedded.line`
- `.source .string .punctuation.section.embedded => .syntax--source .syntax--string .syntax--punctuation.syntax--section.syntax--embedded`
- `.source .string .punctuation.section.embedded .source => .syntax--source .syntax--string .syntax--punctuation.syntax--section.syntax--embedded .syntax--source`
- `.punctuation.terminator => .syntax--punctuation.syntax--terminator`
- `.punctuation.separator => .syntax--punctuation.syntax--separator`
- `.punctuation.definition => .syntax--punctuation.syntax--definition`
- `.punctuation.definition.comment => .syntax--punctuation.syntax--definition.syntax--comment`
- `.punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.array => .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--variable, .syntax--punctuation.syntax--definition.syntax--array`
- `.punctuation.definition.parameters => .syntax--punctuation.syntax--definition.syntax--parameters`
- `.punctuation.definition.heading, .punctuation.definition.identity => .syntax--punctuation.syntax--definition.syntax--heading, .syntax--punctuation.syntax--definition.syntax--identity`
- `.punctuation.definition.bold => .syntax--punctuation.syntax--definition.syntax--bold`
- `.punctuation.definition.italic => .syntax--punctuation.syntax--definition.syntax--italic`
- `.punctuation.section.embedded => .syntax--punctuation.syntax--section.syntax--embedded`
- `.support => .syntax--support`
- `.support.class => .syntax--support.syntax--class`
- `.support.function => .syntax--support.syntax--function`
- `.support.function.any-method => .syntax--support.syntax--function.syntax--any-method`
- `.support.constant => .syntax--support.syntax--constant`
- `.support.type.property-name.css => .syntax--support.syntax--type.syntax--property-name.syntax--css`
- `.source .entity.name.tag, .source .entity.other.attribute-name, .meta.tag.inline, .meta.tag.inline .entity => .syntax--source .syntax--entity.syntax--name.syntax--tag, .syntax--source .syntax--entity.syntax--other.syntax--attribute-name, .syntax--meta.syntax--tag.syntax--inline, .syntax--meta.syntax--tag.syntax--inline .syntax--entity`
- `.tag, .tag .entity => .syntax--tag, .syntax--tag .syntax--entity`
- `.html .string => .syntax--html .syntax--string`
- `.html .punctuation.definition.tag => .syntax--html .syntax--punctuation.syntax--definition.syntax--tag`
- `.html .entity.name.tag => .syntax--html .syntax--entity.syntax--name.syntax--tag`
- `.html .entity.name.tag.structure => .syntax--html .syntax--entity.syntax--name.syntax--tag.syntax--structure`
- `.html .entity.name.tag.block => .syntax--html .syntax--entity.syntax--name.syntax--tag.syntax--block`
- `.html .entity.other.attribute-name => .syntax--html .syntax--entity.syntax--other.syntax--attribute-name`
- `.entity => .syntax--entity`
- `.entity.name.type => .syntax--entity.syntax--name.syntax--type`
- `.entity.other.inherited-class => .syntax--entity.syntax--other.syntax--inherited-class`
- `.entity.name.function => .syntax--entity.syntax--name.syntax--function`
- `.entity.name.class, .entity.name.type.class => .syntax--entity.syntax--name.syntax--class, .syntax--entity.syntax--name.syntax--type.syntax--class`
- `.entity.name.section => .syntax--entity.syntax--name.syntax--section`
- `.entity.name.tag => .syntax--entity.syntax--name.syntax--tag`
- `.entity.other.attribute-name => .syntax--entity.syntax--other.syntax--attribute-name`
- `.entity.other.attribute-name.id => .syntax--entity.syntax--other.syntax--attribute-name.syntax--id`
- `.meta.link => .syntax--meta.syntax--link`
- `.meta.require => .syntax--meta.syntax--require`
- `.meta.brace.curly => .syntax--meta.syntax--brace.syntax--curly`
- `.meta.brace.round => .syntax--meta.syntax--brace.syntax--round`
- `.meta.comma => .syntax--meta.syntax--comma`
- `.meta.selector => .syntax--meta.syntax--selector`
- `.meta.separator => .syntax--meta.syntax--separator`
- `.none => .syntax--none`
- `.markup.bold => .syntax--markup.syntax--bold`
- `.markup.changed => .syntax--markup.syntax--changed`
- `.markup.deleted => .syntax--markup.syntax--deleted`
- `.markup.italic => .syntax--markup.syntax--italic`
- `.markup.heading .punctuation.definition.heading => .syntax--markup.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading`
- `.markup.inserted => .syntax--markup.syntax--inserted`
- `.markup.list => .syntax--markup.syntax--list`
- `.markup.quote => .syntax--markup.syntax--quote`
- `.markup.raw.inline => .syntax--markup.syntax--raw.syntax--inline`
- `.source.gfm .markup => .syntax--source.syntax--gfm .syntax--markup`
- `.source.gfm .markup.heading => .syntax--source.syntax--gfm .syntax--markup.syntax--heading`
- `atom-text-editor[mini] .scroll-view, :host(.mini) .scroll-view => atom-text-editor[mini] .scroll-view,atom-text-editor .scroll-view`
- `.html .meta.tag.any => .syntax--html .syntax--meta.syntax--tag.syntax--any`
- `.html .entity.name.tag.block, .html .entity.name.tag.inline, .html .entity.name.tag.name => .syntax--html .syntax--entity.syntax--name.syntax--tag.syntax--block, .syntax--html .syntax--entity.syntax--name.syntax--tag.syntax--inline, .syntax--html .syntax--entity.syntax--name.syntax--tag.syntax--name`
- `.html .entity.other.attribute-name.id.html => .syntax--html .syntax--entity.syntax--other.syntax--attribute-name.syntax--id.syntax--html`
- `.html .punctuation.separator.key-value => .syntax--html .syntax--punctuation.syntax--separator.syntax--key-value`
- `.html .string.quoted.double => .syntax--html .syntax--string.syntax--quoted.syntax--double`
- `.html .string.quoted.double .punctuation.definition.string.begin, .html .string.quoted.double .punctuation.definition.string.end => .syntax--html .syntax--string.syntax--quoted.syntax--double .syntax--punctuation.syntax--definition.syntax--string.syntax--begin, .syntax--html .syntax--string.syntax--quoted.syntax--double .syntax--punctuation.syntax--definition.syntax--string.syntax--end`
- `.html .string.quoted.double .punctuation.definition.string .separator.key-value.html => .syntax--html .syntax--string.syntax--quoted.syntax--double .syntax--punctuation.syntax--definition.syntax--string .syntax--separator.syntax--key-value.syntax--html`
- `.jade => .syntax--jade`
- `.jade .comment.jade => .syntax--jade .syntax--comment.syntax--jade`
- `.jade .storage.type.function.jade => .syntax--jade .syntax--storage.syntax--type.syntax--function.syntax--jade`
- `.jade .meta.control.flow.jade => .syntax--jade .syntax--meta.syntax--control.syntax--flow.syntax--jade`
- `.jade .source.script .meta.brace.round.js, .jade .source.script .meta.brace.curly.js => .syntax--jade .syntax--source.syntax--script .syntax--meta.syntax--brace.syntax--round.syntax--js, .syntax--jade .syntax--source.syntax--script .syntax--meta.syntax--brace.syntax--curly.syntax--js`
- `.jade .entity.name.tag.jade => .syntax--jade .syntax--entity.syntax--name.syntax--tag.syntax--jade`
- `.jade .storage.type.import.include.jade => .syntax--jade .syntax--storage.syntax--type.syntax--import.syntax--include.syntax--jade`
- `.jade .variable.control.import.include.jade => .syntax--jade .syntax--variable.syntax--control.syntax--import.syntax--include.syntax--jade`
- `.jade .constant.id => .syntax--jade .syntax--constant.syntax--id`
- `.jade .constant.language.js => .syntax--jade .syntax--constant.syntax--language.syntax--js`
- `.jade .text.jade => .syntax--jade .syntax--text.syntax--jade`
- `.jade .punctuation.separator.key-value.jade => .syntax--jade .syntax--punctuation.syntax--separator.syntax--key-value.syntax--jade`
- `.jade .string.quoted.jade => .syntax--jade .syntax--string.syntax--quoted.syntax--jade`
- `.source.json .constant.language => .syntax--source.syntax--json .syntax--constant.syntax--language`
- `.source.json .meta.structure.dictionary.json .string.quoted.json => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--string.syntax--quoted.syntax--json`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .string.quoted.json => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--string.syntax--quoted.syntax--json`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .string.quoted.json .punctuation.definition.string => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--string.syntax--quoted.syntax--json .syntax--punctuation.syntax--definition.syntax--string`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .meta.structure.dictionary.json .string.quoted.json => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--string.syntax--quoted.syntax--json`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .meta.structure.dictionary.json .string.quoted.json .punctuation.definition.string => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--string.syntax--quoted.syntax--json .syntax--punctuation.syntax--definition.syntax--string`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .string.quoted.json => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--string.syntax--quoted.syntax--json`
- `.source.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .meta.structure.dictionary.json .meta.structure.dictionary.value.json .string.quoted.json .punctuation.definition.string => .syntax--source.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--json .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json .syntax--string.syntax--quoted.syntax--json .syntax--punctuation.syntax--definition.syntax--string`
- `.mustache .meta.tag.template => .syntax--mustache .syntax--meta.syntax--tag.syntax--template`
- `.mustache .meta.tag.template .entity.name.tag => .syntax--mustache .syntax--meta.syntax--tag.syntax--template .syntax--entity.syntax--name.syntax--tag`

Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
</p></details>